### PR TITLE
Actions storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -184,3 +184,4 @@ dmypy.json
 # Specific dirs
 uploads
 scratch
+.git


### PR DESCRIPTION
Adding .git to dockerignore freed up over a gig when I tested locally.